### PR TITLE
fix: run system update at start

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           pacman -Sy
+          pacman -Su --noconfirm
           pacman -S --noconfirm 'qt6-base' 'qt6-tools' 'boost-libs' 'openssl' 'qt6-imageformats' 'qtkeychain-qt6' 'qt6-5compat' 'qt6-svg' 'libnotify'
           pacman -S --noconfirm 'git' 'boost' 'cmake' 'ninja' 'clang' 'namcap'
 

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           pacman -Sy
+          pacman -Su --noconfirm
           pacman -S --noconfirm 'qt6-base' 'qt6-tools' 'boost-libs' 'openssl' 'qt6-imageformats' 'qtkeychain-qt6' 'qt6-5compat' 'qt6-svg' 'libnotify'
           pacman -S --noconfirm 'git' 'boost' 'cmake' 'ninja' 'clang' 'namcap'
 


### PR DESCRIPTION
this ensures we're not left with an partial upgrade

in our case, new clang used new version of libxml, and we installed that new
version of clang, but we did not install that new version of libxml,
        causing clang to be confused
